### PR TITLE
chore: Branch name change from API bump

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,7 +5,7 @@ const express = require("express");
 
 const app = express();
 
-const getDownloadCounts = bent("https://raw.githubusercontent.com/goatcorp/DalamudPlugins/api5/downloadcounts.json", "json");
+const getDownloadCounts = bent("https://raw.githubusercontent.com/goatcorp/DalamudPlugins/master/downloadcounts.json", "json");
 
 // Routes
 app.get('/:pluginName', async (req, res) => {


### PR DESCRIPTION
Using `master` to always refer to the main branch instead of the current branch name should prevent future breakage when the API number is increased and the main branch swaps over like it did for the last API bump. At least until Github renames `/master/` to `/main/`.

I don't know if this requires changes elsewhere - this was just a quick glance I made because I miss my download count badge.